### PR TITLE
Default ad class to active false.

### DIFF
--- a/src/ad/index.js
+++ b/src/ad/index.js
@@ -26,7 +26,7 @@ export default class Ad {
    */
   constructor (config = {}) {
     // Use to indercate if the ad has been distroyed.
-    this.active = true;
+    this.active = false;
     // awaitingFactory is used when slecting what ad classes require an creative
     // factory.
     this.awaitingFactory = true;


### PR DESCRIPTION
Changing the default state of the ad class to be false, this stops the destroy method from failing if the ad failed to load.