### PR TITLE
Adding support for the "brand" option in the ad config

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ An optional flag to override link behaviour, making all links open in the same w
 | ---------------- | ------- | -------- | ------- |
 | `linkSameWindow` | Boolean | X        | `false` |
 
+#### `brand`
+
+An optional parameter to pass through the brand identify, sometimes required if you have more than one brand per publication or ad tag. Fresh8 will supply you with this value if needed.
+
+| Key     | Value  | Required | Default     |
+| ------- | ------ | -------- | ----------- |
+| `brand` | String | X        | `undefined` |
+
 ## Ad class
 
 An instantiated ad class is resolved from the `requestAd` method on success

--- a/src/ad/index.js
+++ b/src/ad/index.js
@@ -22,6 +22,7 @@ export default class Ad {
    *                       , endpoint: '' - optional
    *                       , appendPoint: 'body' - required
    *                       , linkSameWindow: true - optional
+   *                       , brand: 'my-brand-name' - optional
    *                       , url: 'http://fresh8gaming.com' - optional
    *                       }
    */

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -19,6 +19,7 @@ import { invaildeConfig } from '../errors';
  *                         , inApp: false - optional
  *                         , endpoint: '' - optional
  *                         , linkSameWindow: true - optional
+ *                         , brand: 'my-brand-name' - optional
  *                         , url: 'http://fresh8gaming.com' - optional
  *                         }
  * @return {Promise}
@@ -40,6 +41,7 @@ export function requestAdData (config) {
       competitionIds: vaildatedConfig.competitionIDs,
       competitions: vaildatedConfig.competitions,
       linkSameWindow: vaildatedConfig.linkSameWindow,
+      brand: vaildatedConfig.brand,
       ref: getRef(vaildatedConfig.window, vaildatedConfig.inApp, vaildatedConfig.url)
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,7 @@ export default class Fresh8 {
    *                         , competitors: ['Manchester United', 'Southampton'] - optinal
    *                         , competitionIDs: ['1245'] - optional Opta ID's
    *                         , competitions: ['Premier League'] - optional
+   *                         , brand: 'my-brand-name' - optional
    *                         }
    *                         For more details on these options please refer to
    *                         the readme.

--- a/test/unit/specs/api/index.spec.js
+++ b/test/unit/specs/api/index.spec.js
@@ -93,7 +93,8 @@ describe('src/api/index.js', () => {
         listenOnPushState: true,
         linkSameWindow: true,
         inApp: true,
-        shouldBreakOut: true
+        shouldBreakOut: true,
+        brand: 'my-stylish-brand'
       };
 
       const conf = vaildateRequestAdConf(options);
@@ -136,11 +137,12 @@ describe('src/api/index.js', () => {
         competitorIds: ['1443', '5677'],
         competitors: ['preston'],
         competitionIds: ['125454'],
-        competitions: ['Premier League']
+        competitions: ['Premier League'],
+        brand: 'my-stylish-brand'
       };
 
       const URL = constructRequestURL('https://fresh8.co/123/raw', options);
-      expect(URL).to.equal('https://fresh8.co/123/raw?inApp=true&linkSameWindow=true&competitorIds=1443,5677&competitors=preston&competitionIds=125454&competitions=Premier%20League&');
+      expect(URL).to.equal('https://fresh8.co/123/raw?inApp=true&linkSameWindow=true&competitorIds=1443,5677&competitors=preston&competitionIds=125454&competitions=Premier%20League&brand=my-stylish-brand&');
     });
 
     it('Should skip empty arrays', () => {


### PR DESCRIPTION
Allow users to pass through the brand parameter in the ad config. This is useful if you have more than one brand per publisher and you want to specify specific ones in each slot.

Relies on #9 being merged first.